### PR TITLE
simplified widget script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,10 @@ var sb_soundplayer_client_id = 'YOUR_CLIENT_ID';
 /* * * DON'T EDIT BELOW THIS LINE * * */
 (function(d, s, id) {
     if (d.getElementById(id)) return;
-    var js, p, fjs = d.getElementsByTagName(s)[0];
-    p = /^http:/.test(d.location) ? 'http' : 'https';
-    js = d.createElement(s);
+    var fjs = d.getElementsByTagName(s)[0],
+        js = fjs.parentNode.insertBefore(d.createElement(s), fjs);
     js.id = id;
-    js.src = p + '://cdnjs.cloudflare.com/ajax/libs/soundplayer-widget/0.3.4/soundplayer-widget.min.js';
-    fjs.parentNode.insertBefore(js, fjs);
+    js.src = '//cdnjs.cloudflare.com/ajax/libs/soundplayer-widget/0.3.4/soundplayer-widget.min.js';
 })(document, 'script', 'sb-soundplayer-widget-sdk');
 </script>
 ```


### PR DESCRIPTION
There are at least two "gotchas" in the widget script:
- `location.protocol` is all you need, the RegExp check won't help with `file://` so I don't understand why is that needed
- if you include a script without the protocol this will be understood automatically

TL;DR in a `https:` page if you script src is `//cdn.js/script.js` it will load from a fully resolved  `https://cdn.js/script.js` while if your page is served from `http:` your script will be loaded from `http://cdn.js/script.js`

I don't know what was the intent of that RegExp and the reason you don't just `location.protocol` so this PR is about forgetting about it and using just the URL without the protocol.

As alternative, if there's something I am missing, that logic could be based on `location.protocol` instead so that if `=== http` uses it otherwise go https ( or actually vice-versa )

Finally, if you were planning to support very old browsers too, you need to set the deprecated `js.type = "text/javascript";` or nothing will happen. Although considering the target for your widget I'd say it's a good thing that nothing would happen there 'cause the widget, as it is, won't work anyway.

Best Regards
